### PR TITLE
Fix effectOfTreatmentonTreated() in harmonic.R

### DIFF
--- a/R/harmonic.R
+++ b/R/harmonic.R
@@ -8,7 +8,6 @@ harmonic <- function(data) {
 }
 
 effectOfTreatmentOnTreated <- function(data) {
-    txcts <- table(as.logical(data$Tx.grp), data$stratum.code)
-    txcts["TRUE",]
-  })
+  txcts <- table(as.logical(data$Tx.grp), data$stratum.code)
+  txcts["TRUE",]
 }


### PR DESCRIPTION
The recent update to effectOfTreatmentOnTreated() needs to also remove the closing "})" from tapply, otherwise the RItools package cannot be installed.

```{r}
* installing *source* package ‘RItools’ ...
** R
Error in parse(outFile) : 
  /private/var/folders/4c/n046s2rj07xgcfcz_3n2n0600000gn/T/RtmpfrfUuC/devtools817a3ff8dda6/markmfredrickson-RItools-cd6de8f/R/h:13:4: unexpected ')'
12:     txcts["TRUE",]
13:   })
       ^
ERROR: unable to collate and parse R files for package ‘RItools’

```