### PR TITLE
Remove reference to data.table from tests

### DIFF
--- a/tests/testthat/test.utils.R
+++ b/tests/testthat/test.utils.R
@@ -143,12 +143,12 @@ test_that("Residuals from weighted regressions w/ sparse designs",
 
           })
 
-test_that("data.table options issue #69", {
-
-  if (suppressMessages(suppressWarnings(require(data.table)))) {
-    data(nuclearplants)
-    f <- function() 1
-    expect_equal(withOptions(list(), f), 1)
-  }
-
-})
+#test_that("data.table options issue #69", {
+#
+#  if (suppressMessages(suppressWarnings(require(data.table)))) {
+#    data(nuclearplants)
+#    f <- function() 1
+#    expect_equal(withOptions(list(), f), 1)
+#  }
+#
+#})


### PR DESCRIPTION
Proposing this patch as a response to an email from Kurt H:

>These seem to have undeclared package dependencies in their unit test code (R files in tests subdirs), see below.
>
>Can you pls fix as necessary?  (Add the missing package dependencies to Suggests, I guess.)
>
> Please note that these issues are currently not yet detected by the CRAN incoming (or regular) checks.
>
>Best
> -k

```
$RItools
'library' or 'require' call not declared from: ‘data.table’
```