### PR TITLE
Address CRAN complaints arising from test for #69, a data.table induced problem 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,6 +4,7 @@ lexicon.txt
 load.R
 inst/docs
 cran-comments.md
+tests/testthat/test.notforCRAN.R
 matrixNotation.Rnw
 .git
 .local

--- a/tests/testthat/test.notforCRAN.R
+++ b/tests/testthat/test.notforCRAN.R
@@ -1,0 +1,15 @@
+### Tests we don't want to have run on CRAN   ###
+### (ordinarily because the test will throw   ###
+### a warning or error during CRAN-checking)  ###
+
+###    tests relocated from test.utils.R      ###
+
+test_that("data.table options issue #69", {
+
+  if (suppressMessages(suppressWarnings(require(data.table)))) {
+    data(nuclearplants)
+    f <- function() 1
+    expect_equal(withOptions(list(), f), 1)
+  }
+
+})

--- a/tests/testthat/test.utils.R
+++ b/tests/testthat/test.utils.R
@@ -143,12 +143,12 @@ test_that("Residuals from weighted regressions w/ sparse designs",
 
           })
 
-#test_that("data.table options issue #69", {
-#
-#  if (suppressMessages(suppressWarnings(require(data.table)))) {
-#    data(nuclearplants)
-#    f <- function() 1
-#    expect_equal(withOptions(list(), f), 1)
-#  }
-#
-#})
+test_that("data.table options issue #69", {
+
+  if (suppressMessages(suppressWarnings(require(data.table)))) {
+    data(nuclearplants)
+    f <- function() 1
+    expect_equal(withOptions(list(), f), 1)
+  }
+
+})

--- a/tests/testthat/test.utils.R
+++ b/tests/testthat/test.utils.R
@@ -143,12 +143,12 @@ test_that("Residuals from weighted regressions w/ sparse designs",
 
           })
 
-test_that("data.table options issue #69", {
-
-  if (suppressMessages(suppressWarnings(require(data.table)))) {
-    data(nuclearplants)
-    f <- function() 1
-    expect_equal(withOptions(list(), f), 1)
-  }
-
-})
+#test_that("data.table options issue #69", {
+#
+#  if (suppressMessages(suppressWarnings(require(data.table)))) {
+#    data(nuclearplants)
+#    f <- function() 1
+#    expect_equal(withOptions(list(), f), 1)
+#  }
+#
+#})

--- a/tests/testthat/test.utils.R
+++ b/tests/testthat/test.utils.R
@@ -142,13 +142,3 @@ test_that("Residuals from weighted regressions w/ sparse designs",
               expect_equal(lmw$residuals, as.vector(slmw$residuals)) # also
 
           })
-
-test_that("data.table options issue #69", {
-
-  if (suppressMessages(suppressWarnings(require(data.table)))) {
-    data(nuclearplants)
-    f <- function() 1
-    expect_equal(withOptions(list(), f), 1)
-  }
-
-})


### PR DESCRIPTION
Sets up a file for tests that we'd like to run, but that we don't want to send to CRAN when we release.  

To stay ahead of regressions, we want to test liberally.  But those sorts of tests are among the most likely to cause trouble with CRAN submissions, because often they involve provoking behavior from another package that differs from what CRAN wants to see. Here is a proposed solution.

My hope is that Travis will still run the tests that have been parked in tests/testthat/test.notforCRAN.R -- I'd appreciate a sound-off from someone who knows a bit about how Travis works.   I'm soliciting Josh's review partly for this reason and partly b/c he's the author of the regression test that this strategy avoids commenting out. 

This is a counter-proposal to the response  to the following email (from Kurt H) that @jwbowers had proposed in #93. 

>These seem to have undeclared package dependencies in their unit test code (R files in tests subdirs), see below.
>
>Can you pls fix as necessary?  (Add the missing package dependencies to Suggests, I guess.)
>
> Please note that these issues are currently not yet detected by the CRAN incoming (or regular) checks.
>
>Best
> -k

```
$RItools
'library' or 'require' call not declared from: ‘data.table’
```