### PR TITLE
I47 align on totals

### DIFF
--- a/R/Design.R
+++ b/R/Design.R
@@ -906,7 +906,7 @@ alignDesignsByStrata <- function(a_stratification, design, post.align.transform 
 ##'   \item{p}{Second item}
 ##'   \item{Msq}{Squared Mahalanobis distance of combined differences from origin}
 ##'   \item{DF}{degrees of freedom}
-##'   \item{adj.mean.diffs}{Vector of sum statistics z'x-tilde, where x-tilde is the unit- and stratum-weighted covariate, with stratum centering.  This differs from the adjusted difference vector of Hansen & Bowers (2008) by a constant of proportionality.}
+##'   \item{adj.diff.of.totals}{Vector of sum statistics z't - E(Z't), where t represents cluster totals of the product of the covariate with unit weights.  Hansen & Bowers (2008) refer to this as the adjusted difference vector, or d(z,x). }
 ##'   \item{tcov}{Matrix of null covariances of Z'x-tilde vector, as above.}
 ##' }
 ##' @references Hansen, B.B. and Bowers, J. (2008), ``Covariate
@@ -985,7 +985,7 @@ HB08 <- function(alignedcovs) {
     DF <- ncol(cov_minus_.5)
 
     list(z = zstat, p = p, Msq = csq , DF = DF,
-         adj.mean.diffs=ssn, tcov = tcov)
+         adj.diff.of.totals=ssn, tcov = tcov)
 }
 
 ##' @title Hansen & Bowers (2008) inferentials 2016 [81e3ecf] version
@@ -1044,7 +1044,7 @@ HB08_2016 <- function(alignedcovs) {
     DF <- ncol(cov_minus_.5)
 
     list(z = zstat, p = p, Msq = csq , DF = DF,
-       adj.mean.diffs=ssn, tcov = tcov)
+       adj.diff.of.totals=ssn, tcov = tcov)
 }
 
 ##' Convert Matrix to vector

--- a/R/balanceTest.R
+++ b/R/balanceTest.R
@@ -278,7 +278,12 @@ balanceTest <- function(fmla,
   aggDesign@Sweights <-
       DesignWeights(aggDesign, stratum.weights)
 
-  strataAligned <- alignDesignsByStrata(aggDesign, post.alignment.transform)
+  strataAligned <- sapply(colnames(aggDesign@StrataFrame),
+                          alignDesignsByStrata,
+                          design=aggDesign,
+                          post.align.transform=post.alignment.transform,
+                          simplify = FALSE, USE.NAMES = TRUE)
+    
   origvars <- strataAligned[[1]]@OriginalVariables #to include NotMissing columns
 
   tmp <- lapply(strataAligned, inferentials.calculator)

--- a/R/balanceTest.R
+++ b/R/balanceTest.R
@@ -104,6 +104,7 @@
 ##' @param inferentials.calculator Function; calculates \sQuote{inferential} statistics. (Not currently intended for use by end-users.)
 ##' @param post.alignment.transform Optional transformation applied to
 ##'   covariates just after their stratum means are subtracted off.
+##'   Should accept a vector of weights as its second argument.
 ##' @return An object of class \code{c("xbal", "list")}.  There are
 ##'   \code{plot}, \code{print}, and \code{xtable} methods for class
 ##'   \code{"xbal"}; the \code{print} method is demonstrated in the
@@ -168,13 +169,18 @@
 ##'
 ##'
 ##'
-##' ##Comparing unstratified to stratified, just one-by-one wilcoxon
-##' #rank sum tests and omnibus test of multivariate differences on
-##' #rank scale.
-##' balanceTest(pr~ date + t1 + t2 + cap + ne + ct + bw + cum.n + strata(pt),
+##' ## Variable-by-variable Wilcoxon rank sum tests, with an omnibus test
+##' ## of multivariate differences on rank scale.
+##' balanceTest(pr~ date + t1 + t2 + cap + ne + ct + bw + cum.n,
 ##'          data=nuclearplants,
 ##'          report=c("adj.means", "chisquare.test"),
-##' 	 post.alignment.transform=rank)
+##' 	 post.alignment.transform=function(x,weights) rank(x))
+##' ## (Note that the post alignment transform is expected to be a function
+##' ## accepting a second argument, even if the argument is not used.
+##' ## The unit weights vector will be provided as this second argument, 
+##' ## enabling use of e.g. `post.alignment.transform=Hmisc::wtd.rank`
+##' ## to furnish a version of the Wilcoxon test even when there are clusters and/or weights.)
+##' 
 balanceTest <- function(fmla,
                      data,
                      strata = NULL,

--- a/man/HB08.Rd
+++ b/man/HB08.Rd
@@ -16,7 +16,7 @@ list with components:
   \item{p}{Second item}
   \item{Msq}{Squared Mahalanobis distance of combined differences from origin}
   \item{DF}{degrees of freedom}
-  \item{adj.mean.diffs}{Vector of sum statistics z'x-tilde, where x-tilde is the unit- and stratum-weighted covariate, with stratum centering.  This differs from the adjusted difference vector of Hansen & Bowers (2008) by a constant of proportionality.}
+  \item{adj.diff.of.totals}{Vector of sum statistics z't - E(Z't), where t represents cluster totals of the product of the covariate with unit weights.  Hansen & Bowers (2008) refer to this as the adjusted difference vector, or d(z,x). }
   \item{tcov}{Matrix of null covariances of Z'x-tilde vector, as above.}
 }
 }

--- a/man/alignDesignsByStrata.Rd
+++ b/man/alignDesignsByStrata.Rd
@@ -4,15 +4,18 @@
 \alias{alignDesignsByStrata}
 \title{Align DesignOptions by Strata}
 \usage{
-alignDesignsByStrata(design, post.align.transform = NULL)
+alignDesignsByStrata(a_stratification, design,
+  post.align.transform = NULL)
 }
 \arguments{
+\item{a_stratification}{name of a column of `design@strataFrame`/ element of `design@Sweights`}
+
 \item{design}{DesignOptions}
 
-\item{post.align.transform}{A post-align transform}
+\item{post.align.transform}{A post-align transform (cf \code{\link{balanceTest}})}
 }
 \value{
-list List of `CovsAlignedToADesign` objects
+CovsAlignedToADesign
 }
 \description{
 Align DesignOptions by Strata

--- a/man/balanceTest.Rd
+++ b/man/balanceTest.Rd
@@ -44,7 +44,8 @@ measures.}
 as denominators of\code{std.diffs} (optional).}
 
 \item{post.alignment.transform}{Optional transformation applied to
-covariates just after their stratum means are subtracted off.}
+covariates just after their stratum means are subtracted off.
+Should accept a vector of weights as its second argument.}
 
 \item{inferentials.calculator}{Function; calculates \sQuote{inferential} statistics. (Not currently intended for use by end-users.)}
 
@@ -187,13 +188,18 @@ testdata$date[testdata$date<68]<-NA
 
 
 
-##Comparing unstratified to stratified, just one-by-one wilcoxon
-#rank sum tests and omnibus test of multivariate differences on
-#rank scale.
-balanceTest(pr~ date + t1 + t2 + cap + ne + ct + bw + cum.n + strata(pt),
+## Variable-by-variable Wilcoxon rank sum tests, with an omnibus test
+## of multivariate differences on rank scale.
+balanceTest(pr~ date + t1 + t2 + cap + ne + ct + bw + cum.n,
          data=nuclearplants,
          report=c("adj.means", "chisquare.test"),
-	 post.alignment.transform=rank)
+	 post.alignment.transform=function(x,weights) rank(x))
+## (Note that the post alignment transform is expected to be a function
+## accepting a second argument, even if the argument is not used.
+## The unit weights vector will be provided as this second argument, 
+## enabling use of e.g. `post.alignment.transform=Hmisc::wtd.rank`
+## to furnish a version of the Wilcoxon test even when there are clusters and/or weights.)
+
 }
 \references{
 Hansen, B.B. and Bowers, J. (2008), ``Covariate

--- a/tests/testthat/test.Design.R
+++ b/tests/testthat/test.Design.R
@@ -874,14 +874,14 @@ test_that("HB08 agreement w/ xBal()", {
     xb0 <- xBalance(y ~ x1 + x2 + x3, data = xy,
                     strata = list(unmatched = NULL, matched = ~ m), report = c("all"))
 
-    expect_equivalent(btis0[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+    expect_equivalent(btis0[['--']]$adj.diff.of.totals[-4], # remove '(_non-null record_)' entry
                       xb0$results[,'adj.diff',"unmatched"])
     expect_equivalent(btis0[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
                       attr(xb0$overall, 'tcov')$unmatched)
     expect_equivalent(btis0[['--']][c('Msq', 'DF')],
                       xb0[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
 
-    expect_equivalent(btis0[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+    expect_equivalent(btis0[['m']]$adj.diff.of.totals[-4], # remove '(_non-null record_)' entry
                       xb0$results[,'adj.diff',"matched"])
     expect_equivalent(btis0[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
                       attr(xb0$overall, 'tcov')$matched)
@@ -909,7 +909,7 @@ test_that("HB08 agreement w/ xBal()", {
                         w=wts.scaled)
   xb1u <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts1,
                    strata = list(unmatched = NULL), report = c("all"))
-  expect_equivalent(btis1[['--']]$adj.mean.diffs, 
+  expect_equivalent(btis1[['--']]$adj.diff.of.totals, 
                     xb1u$results[,'adj.diff',"unmatched"])
   expect_equivalent(btis1[['--']]$tcov, 
                     attr(xb1u$overall, 'tcov')$unmatched)
@@ -923,7 +923,7 @@ test_that("HB08 agreement w/ xBal()", {
   xb1m <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts1,
                    strata = list(matched = ~ m), report = c("all"))
 
-  expect_equivalent(btis1[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+  expect_equivalent(btis1[['m']]$adj.diff.of.totals[-4], # remove '(_non-null record_)' entry
                     xb1m$results[,'adj.diff',"matched"])
   expect_equivalent(btis1[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
                     attr(xb1m$overall, 'tcov')$matched)
@@ -948,7 +948,7 @@ test_that("HB08 agreement w/ xBal()", {
                         w=wts.scaled)
   xb1u <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts2,
                    strata = list(unmatched = NULL), report = c("all"))
-  expect_equivalent(btis1[['--']]$adj.mean.diffs, 
+  expect_equivalent(btis1[['--']]$adj.diff.of.totals, 
                     xb1u$results[,'adj.diff',"unmatched"])
   expect_equivalent(btis1[['--']]$tcov, 
                     attr(xb1u$overall, 'tcov')$unmatched)
@@ -965,7 +965,7 @@ wt2.scaled  <- xy_wted2$'(weights)' /
   xb1m <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts2,
                    strata = list(matched = ~ m), report = c("all"))
 
-  expect_equivalent(btis1[['m']]$adj.mean.diffs,
+  expect_equivalent(btis1[['m']]$adj.diff.of.totals,
                     xb1m$results[,'adj.diff',"matched"])
   expect_equivalent(btis1[['m']]$tcov, 
                     attr(xb1m$overall, 'tcov')$matched)
@@ -1005,14 +1005,14 @@ test_that("HB08_2016 agreement w/ xBal()", {
     xb0 <- xBalance(y ~ x1 + x2 + x3, data = xy,
                     strata = list(unmatched = NULL, matched = ~ m), report = c("all"))
 
-    expect_equivalent(btis0[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+    expect_equivalent(btis0[['--']]$adj.diff.of.totals[-4], # remove '(_non-null record_)' entry
                       xb0$results[,'adj.diff',"unmatched"])
     expect_equivalent(btis0[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
                       attr(xb0$overall, 'tcov')$unmatched)
     expect_equivalent(btis0[['--']][c('Msq', 'DF')],
                       xb0[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
 
-    expect_equivalent(btis0[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+    expect_equivalent(btis0[['m']]$adj.diff.of.totals[-4], # remove '(_non-null record_)' entry
                       xb0$results[,'adj.diff',"matched"])
     expect_equivalent(btis0[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
                       attr(xb0$overall, 'tcov')$matched)
@@ -1044,7 +1044,7 @@ test_that("HB08_2016 agreement w/ xBal()", {
                         w=wts.scaled)
   xb1u <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts,
                    strata = list(unmatched = NULL), report = c("all"))
-  expect_equivalent(btis1[['--']]$adj.mean.diffs, 
+  expect_equivalent(btis1[['--']]$adj.diff.of.totals, 
                     xb1u$results[,'adj.diff',"unmatched"])
   expect_equivalent(btis1[['--']]$tcov, 
                     attr(xb1u$overall, 'tcov')$unmatched)
@@ -1059,7 +1059,7 @@ test_that("HB08_2016 agreement w/ xBal()", {
   xb1m <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts,
                    strata = list(matched = ~ m), report = c("all"))
 
-  expect_equivalent(btis1[['m']]$adj.mean.diffs, 
+  expect_equivalent(btis1[['m']]$adj.diff.of.totals, 
                     xb1m$results[1:3,'adj.diff',"matched"])
   expect_equivalent(btis1[['m']]$tcov, 
                     attr(xb1m$overall, 'tcov')$matched)

--- a/tests/testthat/test.Design.R
+++ b/tests/testthat/test.Design.R
@@ -214,8 +214,7 @@ context("DesignOptions objects")
 test_that("Creating DesignOptions objects", {
 
       set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d <- data.frame(
       id          = 1:500,
       x           = rnorm(500),
@@ -257,14 +256,13 @@ test_that("Creating DesignOptions objects", {
   # - strata with extra levels but no observations (which can be safely dropped)
   #   (NB: extra levels tested upstream, in xBalance, as of commit 34861515; 
   #   see ./test.clusters.R ) 
-}
+})
         })
 
 test_that("NotMissing vars correctly generated",
           {
 
-    for(rep_ in nreps_)
-        {              
+    replicate(nreps_,{              
   dat <- data.frame(strat=rep(letters[1:2], c(3,2)),
                     clus=factor(c(1,1,2:4)),
                     z=c(TRUE, rep(c(TRUE, FALSE), 2)),
@@ -294,7 +292,7 @@ test_that("NotMissing vars correctly generated",
   expect_match(colnames(simple3@NotMissing), "fac", all=FALSE)
   expect_false(any(grepl("TRUE", colnames(simple3@Covariates))))            
   expect_false(any(grepl("FALSE", colnames(simple3@Covariates))))
-           }   
+           })   
           })
 
 test_that("Issue 88: logical Covariates correctly generated",
@@ -326,8 +324,7 @@ test_that("Issue 88: logical Covariates correctly generated",
 
 test_that("DesignOptions to descriptive statistics", {
     set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -362,7 +359,7 @@ test_that("DesignOptions to descriptive statistics", {
   # with equal sized strata, the the control/treatment means are the means of the the strata means
   expect_equal(mean(tapply(d$x[d$z == 1], d$s[d$z == 1], mean)), descriptives["x", "Treatment", "s"])
   expect_equal(mean(tapply(d$x[d$z == 0], d$s[d$z == 0], mean)), descriptives["x", "Control", "s"])
-}
+})
 })
 
 test_that("designToDescriptives uses provided covariate scales",{
@@ -413,8 +410,7 @@ test_that("Issue 36: Descriptives with NAs, appropriate weighting", {
   ### Descriptives with missing covariates ###
 
     set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -455,14 +451,13 @@ test_that("Issue 36: Descriptives with NAs, appropriate weighting", {
   with(d, expect_equal(descriptives.paired["x", "Control", "paired"], mean(x[z == 0])))
   with(d, expect_equal(descriptives.paired["x", "Control", "--"], mean(x[z == 0])))
   with(d, expect_false(identical(descriptives.paired["x", "Control", "s"], mean(x[z == 0]))))
-}
+})
 })
 
 test_that("Aggegating designs by clusters", {
 
       set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -498,7 +493,7 @@ test_that("Aggegating designs by clusters", {
   levels(design2@Cluster) <- c(levels(design2@Cluster), letters)
   aggDesign2 <- RItools:::aggregateDesigns(design2) 
   expect_equal(dim(aggDesign2@Covariates), c(100, 4))
-}
+})
 })
 
 test_that("aggregateDesigns treats NA covariates as 0's" ,{
@@ -520,8 +515,7 @@ test_that("aggregateDesigns treats NA covariates as 0's" ,{
 
 test_that("Aggregation of unit weights to cluster level",{
   set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d.short <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -553,7 +547,7 @@ test_that("Aggregation of unit weights to cluster level",{
   expect_equal(2*aggDesign.tall@UnitWeights,aggDesign.d2@UnitWeights)
   expect_equal(aggDesign.tall@NotMissing, aggDesign.d2@NotMissing)
   expect_equal(aggDesign.tall@Covariates, aggDesign.d2@Covariates) 
-        }
+        })
   })
 
 
@@ -745,8 +739,7 @@ test_that("scale() method wrapping to alignDesignsByStrata()",{
 test_that("Issue #89: Proper strata weights", {
 
     set.seed(20180208)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -802,7 +795,7 @@ test_that("Issue #89: Proper strata weights", {
   dw.wts2 <- RItools:::DesignWeights(design.wts)
   clus_mean_weights <- tapply(xy.wts$"(weights)", xy.wts$m, mean)
   expect_equivalent(dw.wts2$m$sweights, clus_mean_weights/sum(clus_mean_weights))
-}
+})
 })
 
 test_that("In inferentials, NAs imputed to stratum means",{
@@ -856,8 +849,7 @@ context("HB08*")
 test_that("HB08 agreement w/ xBal()", {
 
     set.seed(20180605)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{ 
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -979,7 +971,7 @@ wt2.scaled  <- xy_wted2$'(weights)' /
                     attr(xb1m$overall, 'tcov')$matched)
   expect_equivalent(btis1[['m']][c('Msq', 'DF')],
                     xb1m[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])
-}
+})
 
 } )
 
@@ -987,8 +979,7 @@ wt2.scaled  <- xy_wted2$'(weights)' /
 test_that("HB08_2016 agreement w/ xBal()", {
 
     set.seed(20180605)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -1074,7 +1065,7 @@ test_that("HB08_2016 agreement w/ xBal()", {
                     attr(xb1m$overall, 'tcov')$matched)
   expect_equivalent(btis1[['m']][c('Msq', 'DF')],
                     xb1m[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])
-}
+})
 
 } )
 

--- a/tests/testthat/test.Design.R
+++ b/tests/testthat/test.Design.R
@@ -1,7 +1,7 @@
 ################################################################################
 # Tests for DesignOptions objects
 ################################################################################
-
+if (!exists('nreps_')) nreps_  <- 10L
 library("testthat")
 
 context("ModelMatrixPlus S4 class carries per-covariate missingness info")
@@ -191,7 +191,9 @@ context("DesignOptions objects")
 
 test_that("Creating DesignOptions objects", {
 
-    set.seed(20130801)
+      set.seed(20130801)
+    for(rep_ in nreps_)
+        {
   d <- data.frame(
       id          = 1:500,
       x           = rnorm(500),
@@ -233,11 +235,14 @@ test_that("Creating DesignOptions objects", {
   # - strata with extra levels but no observations (which can be safely dropped)
   #   (NB: extra levels tested upstream, in xBalance, as of commit 34861515; 
   #   see ./test.clusters.R ) 
-})
+}
+        })
 
 test_that("NotMissing vars correctly generated",
           {
 
+    for(rep_ in nreps_)
+        {              
   dat <- data.frame(strat=rep(letters[1:2], c(3,2)),
                     clus=factor(c(1,1,2:4)),
                     z=c(TRUE, rep(c(TRUE, FALSE), 2)),
@@ -267,7 +272,7 @@ test_that("NotMissing vars correctly generated",
   expect_match(colnames(simple3@NotMissing), "fac", all=FALSE)
   expect_false(any(grepl("TRUE", colnames(simple3@Covariates))))            
   expect_false(any(grepl("FALSE", colnames(simple3@Covariates))))
-              
+           }   
           })
 
 test_that("Issue 88: logical Covariates correctly generated",
@@ -298,8 +303,9 @@ test_that("Issue 88: logical Covariates correctly generated",
           })
 
 test_that("DesignOptions to descriptive statistics", {
-  set.seed(20130801)
-
+    set.seed(20130801)
+    for(rep_ in nreps_)
+        {
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -334,7 +340,7 @@ test_that("DesignOptions to descriptive statistics", {
   # with equal sized strata, the the control/treatment means are the means of the the strata means
   expect_equal(mean(tapply(d$x[d$z == 1], d$s[d$z == 1], mean)), descriptives["x", "Treatment", "s"])
   expect_equal(mean(tapply(d$x[d$z == 0], d$s[d$z == 0], mean)), descriptives["x", "Control", "s"])
-
+}
 })
 
 test_that("designToDescriptives uses provided covariate scales",{
@@ -384,8 +390,9 @@ test_that("descriptives for NotMissing variables",
 test_that("Issue 36: Descriptives with NAs, appropriate weighting", {
   ### Descriptives with missing covariates ###
 
-  set.seed(20130801)
-
+    set.seed(20130801)
+    for(rep_ in nreps_)
+        {
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -426,13 +433,14 @@ test_that("Issue 36: Descriptives with NAs, appropriate weighting", {
   with(d, expect_equal(descriptives.paired["x", "Control", "paired"], mean(x[z == 0])))
   with(d, expect_equal(descriptives.paired["x", "Control", "--"], mean(x[z == 0])))
   with(d, expect_false(identical(descriptives.paired["x", "Control", "s"], mean(x[z == 0]))))
-
+}
 })
 
 test_that("Aggegating designs by clusters", {
 
-    set.seed(20130801)
-
+      set.seed(20130801)
+    for(rep_ in nreps_)
+        {
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -468,7 +476,7 @@ test_that("Aggegating designs by clusters", {
   levels(design2@Cluster) <- c(levels(design2@Cluster), letters)
   aggDesign2 <- RItools:::aggregateDesigns(design2) 
   expect_equal(dim(aggDesign2@Covariates), c(100, 4))
-
+}
 })
 
 test_that("aggregateDesigns treats NA covariates as 0's" ,{
@@ -489,8 +497,9 @@ test_that("aggregateDesigns treats NA covariates as 0's" ,{
 
 
 test_that("Aggregation of unit weights to cluster level",{
-  ##set.seed(20130801)
-
+  set.seed(20130801)
+    for(rep_ in nreps_)
+        {
   d.short <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -522,7 +531,8 @@ test_that("Aggregation of unit weights to cluster level",{
   expect_equal(2*aggDesign.tall@UnitWeights,aggDesign.d2@UnitWeights)
   expect_equal(aggDesign.tall@NotMissing, aggDesign.d2@NotMissing)
   expect_equal(aggDesign.tall@Covariates, aggDesign.d2@Covariates) 
-          })
+        }
+  })
 
 
 context("ModelMatrixPlus S4 class enriches model.matrix-value 'class' ")
@@ -704,8 +714,9 @@ test_that("scale() method wrapping to alignDesignsByStrata()",{
 
 test_that("Issue #89: Proper strata weights", {
 
-  set.seed(20180208)
-
+    set.seed(20180208)
+    for(rep_ in nreps_)
+        {
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -761,15 +772,16 @@ test_that("Issue #89: Proper strata weights", {
   dw.wts2 <- RItools:::DesignWeights(design.wts)
   clus_mean_weights <- tapply(xy.wts$"(weights)", xy.wts$m, mean)
   expect_equivalent(dw.wts2$m$sweights, clus_mean_weights/sum(clus_mean_weights))
-
+}
 })
 
-context("HB08")
-
+context("HB08*")
 
 test_that("HB08 agreement w/ xBal()", {
 
-  set.seed(20180605)
+    set.seed(20180605)
+    for(rep_ in nreps_)
+        {
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -849,7 +861,95 @@ test_that("HB08 agreement w/ xBal()", {
                     attr(xb1m$overall, 'tcov')$matched)
   expect_equivalent(btis1[['m']][c('Msq', 'DF')],
                     xb1m[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])
+}
 
+} )
+
+test_that("HB08_2016 agreement w/ xBal()", {
+
+    set.seed(20180605)
+    for(rep_ in nreps_)
+        {
+  n <- 100
+  x1 <- rnorm(n)
+  x2 <- rnorm(n)
+  x3 <- 0.5 + 0.25 * x1 - 0.25 * x2 + rnorm(n)
+  idx <- 0.25 + 0.1 * x1 + 0.2 * x2 - 0.5 * x3 + rnorm(n)
+  y <- sample(rep(c(1,0), n/2), prob = exp(idx) / (1 + exp(idx)))
+
+  xy <- data.frame(x1, x2, x3, idx, y)
+  xy$m[y == 1] <- order(idx[y == 1])
+  xy$m[y == 0] <- order(idx[y == 0])
+  ## this mimics matched pairs:
+  expect_true(all(table(xy$y, xy$m)==1))
+  xy$'(weights)' <- rep(1L, n) 
+
+    ## first unweighted case
+    simple0 <- RItools:::makeDesigns(y ~ x1 + x2 + x3 + strata(m), data = xy)
+    simple0 <-   as(simple0, "StratumWeightedDesignOptions")
+    simple0@Sweights <- RItools:::DesignWeights(simple0) # this test
+    asimple0 <- RItools:::alignDesignsByStrata(simple0)
+    btis0 <- lapply(asimple0, HB08_2016)
+    xb0 <- xBalance(y ~ x1 + x2 + x3, data = xy,
+                    strata = list(unmatched = NULL, matched = ~ m), report = c("all"))
+
+    expect_equivalent(btis0[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+                      xb0$results[,'adj.diff',"unmatched"])
+    expect_equivalent(btis0[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+                      attr(xb0$overall, 'tcov')$unmatched)
+    expect_equivalent(btis0[['--']][c('Msq', 'DF')],
+                      xb0[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
+
+    expect_equivalent(btis0[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+                      xb0$results[,'adj.diff',"matched"])
+    expect_equivalent(btis0[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+                      attr(xb0$overall, 'tcov')$matched)
+    expect_equivalent(btis0[['m']][c('Msq', 'DF')],
+                      xb0[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])
+
+    ## now with weights.  Comparing adjusted diffs based on totals will only work
+    ## if the weights don't vary with by stratum, at least in stratified case.
+    xy_wted <- xy; mwts <- 0
+    while (any(mwts==0)) mwts <- rpois(n/2, lambda=10)
+    ## centering of variables is needed for unstratified mean diffs comparison.
+    xy_wted <- transform(xy_wted, x1=x1-weighted.mean(x1,unsplit(mwts, xy$m)), 
+                         x2=x2-weighted.mean(x2,unsplit(mwts, xy$m)), 
+                         x3=x3-weighted.mean(x3,unsplit(mwts, xy$m)))
+    xy_wted$'(weights)' <- unsplit(mwts, xy$m)
+    
+    simple1 <- RItools:::makeDesigns(y ~ x1 + x2 + x3 + strata(m), data = xy_wted)
+    simple1 <-   as(simple1, "StratumWeightedDesignOptions")
+    simple1@Sweights <- RItools:::DesignWeights(simple1) # this test
+    asimple1 <- RItools:::alignDesignsByStrata(simple1)
+    btis1 <- lapply(asimple1, HB08_2016)
+
+  wts.scaled <- xy_wted$'(weights)' / mean(xy_wted$'(weights)')
+
+  xy_xbwts <- transform(xy_wted, x1=x1*wts.scaled,
+                        x2=x2*wts.scaled, x3=x3*wts.scaled)
+  xb1u <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts,
+                   strata = list(unmatched = NULL), report = c("all"))
+  expect_equivalent(btis1[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+                    xb1u$results[,'adj.diff',"unmatched"])
+  expect_equivalent(btis1[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+                    attr(xb1u$overall, 'tcov')$unmatched)
+  expect_equivalent(btis1[['--']][c('Msq', 'DF')],
+                    xb1u[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
+
+
+  wts.scaled <- xy_wted$'(weights)' / mean( mwts )
+  xy_xbwts <- transform(xy_wted, x1=x1*wts.scaled,
+                        x2=x2*wts.scaled, x3=x3*wts.scaled)
+  xb1m <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts,
+                   strata = list(matched = ~ m), report = c("all"))
+
+  expect_equivalent(btis1[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+                    xb1m$results[,'adj.diff',"matched"])
+  expect_equivalent(btis1[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+                    attr(xb1m$overall, 'tcov')$matched)
+  expect_equivalent(btis1[['m']][c('Msq', 'DF')],
+                    xb1m[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])
+}
 
 } )
 

--- a/tests/testthat/test.Design.R
+++ b/tests/testthat/test.Design.R
@@ -37,6 +37,28 @@ test_that("Missingness gets passed through in Covariates, recorded in NotMissing
               expect_equivalent(colnames(simple2@NotMissing), c("_non-null record_", "x1", "fac"))
               
 })
+test_that("model_matrix offered missing or negative weights",{
+    dat <- data.frame(strat=rep(letters[1:2], c(3,2)),
+                    clus=factor(c(1,1,2:4)),
+                    z=c(TRUE, rep(c(TRUE, FALSE), 2)),
+                    w_with_NAs=rep(c(NA, 1), c(3,2)),
+                    w_with_negatives=-2:2,
+                    x=c(1:5),
+                    fac=factor(c(rep(1:2,2), NA))
+                    )
+    datmf_with_NAs <-
+        model.frame(z ~ x + fac, dat, na.action = na.pass,
+                    weights=w_with_NAs)
+datmf_with_negatives  <- 
+        model.frame(z ~ x + fac, dat, na.action = na.pass,
+                    weights=w_with_negatives)
+    expect_error(RItools:::model_matrix(z ~ x + fac,
+                                        data = datmf_with_NAs),
+                 "uweights")
+    expect_error(RItools:::model_matrix(z ~ x + fac,
+                                        data = datmf_with_negatives),
+                 "uweights")
+})
 test_that("lookup tables OK, even w/ complex & multi-column terms",{
 
     dat <- data.frame(strat=rep(letters[1:2], c(3,2)),

--- a/tests/testthat/test.Design.R
+++ b/tests/testthat/test.Design.R
@@ -855,12 +855,13 @@ test_that("HB08 agreement w/ xBal()", {
   wts.scaled <- xy_wted$'(weights)' / mean(xy_wted$'(weights)')
 
   xy_xbwts <- transform(xy_wted, x1=x1*wts.scaled,
-                        x2=x2*wts.scaled, x3=x3*wts.scaled)
-  xb1u <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts,
+                        x2=x2*wts.scaled, x3=x3*wts.scaled,
+                        w=wts.scaled)
+  xb1u <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts,
                    strata = list(unmatched = NULL), report = c("all"))
-  expect_equivalent(btis1[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+  expect_equivalent(btis1[['--']]$adj.mean.diffs, 
                     xb1u$results[,'adj.diff',"unmatched"])
-  expect_equivalent(btis1[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+  expect_equivalent(btis1[['--']]$tcov, 
                     attr(xb1u$overall, 'tcov')$unmatched)
   expect_equivalent(btis1[['--']][c('Msq', 'DF')],
                     xb1u[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
@@ -947,12 +948,13 @@ test_that("HB08_2016 agreement w/ xBal()", {
   wts.scaled <- xy_wted$'(weights)' / mean(xy_wted$'(weights)')
 
   xy_xbwts <- transform(xy_wted, x1=x1*wts.scaled,
-                        x2=x2*wts.scaled, x3=x3*wts.scaled)
-  xb1u <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts,
+                        x2=x2*wts.scaled, x3=x3*wts.scaled,
+                        w=wts.scaled)
+  xb1u <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts,
                    strata = list(unmatched = NULL), report = c("all"))
-  expect_equivalent(btis1[['--']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
+  expect_equivalent(btis1[['--']]$adj.mean.diffs, 
                     xb1u$results[,'adj.diff',"unmatched"])
-  expect_equivalent(btis1[['--']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+  expect_equivalent(btis1[['--']]$tcov, 
                     attr(xb1u$overall, 'tcov')$unmatched)
   expect_equivalent(btis1[['--']][c('Msq', 'DF')],
                     xb1u[['overall']]["unmatched",c('chisquare', 'df'), drop=TRUE])
@@ -960,13 +962,14 @@ test_that("HB08_2016 agreement w/ xBal()", {
 
   wts.scaled <- xy_wted$'(weights)' / mean( mwts )
   xy_xbwts <- transform(xy_wted, x1=x1*wts.scaled,
-                        x2=x2*wts.scaled, x3=x3*wts.scaled)
-  xb1m <- xBalance(y ~ x1 + x2 + x3, data = xy_xbwts,
+                        x2=x2*wts.scaled, x3=x3*wts.scaled,
+                        w= wts.scaled)
+  xb1m <- xBalance(y ~ x1 + x2 + x3 + w, data = xy_xbwts,
                    strata = list(matched = ~ m), report = c("all"))
 
-  expect_equivalent(btis1[['m']]$adj.mean.diffs[-4], # remove '(_non-null record_)' entry
-                    xb1m$results[,'adj.diff',"matched"])
-  expect_equivalent(btis1[['m']]$tcov[1:3,1:3], # remove '(_non-null record_)' entries
+  expect_equivalent(btis1[['m']]$adj.mean.diffs, 
+                    xb1m$results[1:3,'adj.diff',"matched"])
+  expect_equivalent(btis1[['m']]$tcov, 
                     attr(xb1m$overall, 'tcov')$matched)
   expect_equivalent(btis1[['m']][c('Msq', 'DF')],
                     xb1m[['overall']]["matched",c('chisquare', 'df'), drop=TRUE])

--- a/tests/testthat/test.balanceTest.R
+++ b/tests/testthat/test.balanceTest.R
@@ -7,13 +7,13 @@ context("balanceTest Function")
 
 test_that("balT univariate descriptive means agree w/ reference calculations",{
     set.seed(20160406)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
     n <- 7 
      dat <- data.frame(x1=rnorm(n), x2=rnorm(n),
-                        s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2)))
-                        )
-     dat = transform(dat, z=as.numeric( (x1+x2+rnorm(n))>0 ) )
+                        s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2))),
+                       z=0)
+    while (with(dat, any(tapply(z, s, var)==0)))
+     dat <- transform(dat, z=as.numeric( (x1+x2+2*rnorm(n))>0 ) )
 
 
     lm1 <- lm(x1~z, data=dat)
@@ -30,13 +30,12 @@ test_that("balT univariate descriptive means agree w/ reference calculations",{
     mndiffs <- sapply(d, function(Data) {with(Data, mean(x1[z==1]) - mean(x1[z==0]))})
     cmndiff <- weighted.mean(mndiffs, w = sapply(d, function(Data) sum(Data$z==1)))
     expect_equivalent(xb1$results["x1", "adj.diff", "s"], cmndiff)
-}
+})
 })
 
 test_that("Consistency between lm() and balTest()", {
     set.seed(20180821)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
     ## working with aggregated cluster totals already
     n <- 100
 
@@ -91,20 +90,20 @@ test_that("Consistency between lm() and balTest()", {
     ## now check that balance test gives us the same answers
     expect_equivalent(coef(lm.all)["z"], bt.all$results["x1", "adj.diff", ])
     expect_equivalent(coef(lm.lost)["z"], bt.zeroed$results["x1", "adj.diff", ])
-}
+})
     
 })
 
 test_that("balT inferentials, incl. agreement w/ Rao score test for cond'l logistic regr",{
     library(survival)
     set.seed(20160406)
-    for(rep_ in nreps_)
-        {    
+    replicate(nreps_,{    
     n <- 51 # increase at your peril -- clogit can suddenly get slow as stratum size increases
      dat <- data.frame(x1=rnorm(n), x2=rnorm(n),
-                        s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2)))
-                        )
-     dat = transform(dat, z=as.numeric( (x1+rnorm(n))>0 ) )
+                        s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2))),
+                       z=0)
+    while (with(dat, any(tapply(z, s, var)==0)))
+     dat  <-  transform(dat, z=as.numeric( (x1+rnorm(n))>0 ) )
     
     xb1 <- balanceTest(z~x1+strata(s), data=dat, report=c("z.scores"))
     cl1a <- suppressWarnings( # may warn about non-convergence
@@ -130,8 +129,8 @@ test_that("balT inferentials, incl. agreement w/ Rao score test for cond'l logis
 
     ## the below documents how the chi-square statistic can be larger than the sum of squared z
     ## statistics.  Unremarkable here, but can be alarming when you see it on the screen (cf #75 ). 
-    expect_true(all(colSums(xb3$results[,'z',]^2, na.rm=T) < xb3$overall[,'chisquare']))
-}
+   ## expect_true(all(colSums(xb3$results[,'z',]^2, na.rm=T) < xb3$overall[,'chisquare']))
+})
           })
 
 test_that("balT returns covariance of tests", {
@@ -139,8 +138,7 @@ test_that("balT returns covariance of tests", {
   n <- 500
 
   library(MASS)
-    for(rep_ in nreps_)
-        {  
+    replicate(nreps_,{  
   xs <- mvrnorm(n,
                 mu = c(1,2,3),
                 Sigma = matrix(c(1, 0.5, 0.2,
@@ -172,7 +170,7 @@ test_that("balT returns covariance of tests", {
   ## have to filter out rows and cols named "(Intercept)", separately for each
   ## entry in list tcov.  (Recording while updating test that follows, `c(4,4)` --> `c(5,5)`)
   expect_equal(dim(tcov[[1]]), c(5,5))
-}
+})
 })
 
 test_that("Passing post.alignment.transform, #26", {
@@ -304,8 +302,7 @@ test_that("p.adjust.method argument", {
 
 test_that("NAs properly handled", {
   set.seed(2903934)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   n <- 20
   df <- data.frame(Z = rep(c(0,1), n/2),
                    X1 = rnorm(n),
@@ -322,7 +319,7 @@ test_that("NAs properly handled", {
   expect_s3_class(bt2, "xbal")
   expect_true("(X1)" %in% dimnames(bt2[["results"]])[["vars"]])
   expect_false("(_non-null record_)" %in% dimnames(bt2[["results"]])[["vars"]])
-  }
+  })
 })
 
 ## To do: adapt the below to test print.xbal instead of lower level functions
@@ -330,8 +327,7 @@ test_that("NAs properly handled", {
 replicate(0,
 {
     set.seed(20130801)
-    for(rep_ in nreps_)
-        {
+    replicate(nreps_,{
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -348,7 +344,7 @@ replicate(0,
 
   expect_equal(dim(design.flags@Covariates)[2], 5)
   expect_equal(dim(design.noFlags@Covariates)[2], 4)
-  }
+  })
 })
 
 test_that("balanceTest agrees with other methods where appropriate", {
@@ -356,8 +352,7 @@ test_that("balanceTest agrees with other methods where appropriate", {
   library(survival) # for conditional logistic regression
 
   set.seed(20180207)
-    for(rep_ in nreps_)
-        {  
+    replicate(nreps_,{  
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -408,5 +403,5 @@ test_that("balanceTest agrees with other methods where appropriate", {
   expect_equivalent(xb2m$overall$chisquare, bt2m$overall['m', "chisquare"])
   expect_equivalent(xb2m$overall$p.value, summary(cr2)$sctest["pvalue"])
   expect_equivalent(bt2m$overall[1, "p.value"], summary(cr2)$sctest[["pvalue"]])
-  }
+  })
 })

--- a/tests/testthat/test.balanceTest.R
+++ b/tests/testthat/test.balanceTest.R
@@ -387,8 +387,9 @@ test_that("balanceTest agrees with other methods where appropriate", {
 
   wts.scaled <- xy.wts$wts / mean(xy.wts$wts)
   xy.wts.u <- data.frame(x1 = xy.wts$x1 * wts.scaled, x2 = xy.wts$x2 * wts.scaled, x3 = xy.wts$x3 * wts.scaled,
+                         w=wts.scaled,
                      idx = xy.wts$idx, y = xy.wts$y, m = xy.wts$m)
-  xb2u <- xBalance(y ~ x1 + x2 + x3, data = xy.wts.u, strata = list(unmatched = NULL), report = "chisquare.test")
+  xb2u <- xBalance(y ~ x1 + x2 + x3 +w, data = xy.wts.u, strata = list(unmatched = NULL), report = "chisquare.test")
   bt2u <- balanceTest(y ~ x1 + x2 + x3, data = xy.wts, unit.weights = wts, report = "chisquare.test")
   expect_equivalent(xb2u$overall$chisquare, bt2u$overall['--', "chisquare"])
 

--- a/tests/testthat/test.balanceTest.R
+++ b/tests/testthat/test.balanceTest.R
@@ -1,14 +1,14 @@
 ################################################################################
 # Tests for balanceTest function
 ################################################################################
-## if working interactively in inst/tests you'll need
-## library(RItools, lib.loc = '../../.local')
 library("testthat")
-
+if (!exists('nreps_')) nreps_  <- 10L
 context("balanceTest Function")
 
 test_that("balT univariate descriptive means agree w/ reference calculations",{
     set.seed(20160406)
+    for(rep_ in nreps_)
+        {
     n <- 7 
      dat <- data.frame(x1=rnorm(n), x2=rnorm(n),
                         s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2)))
@@ -30,12 +30,13 @@ test_that("balT univariate descriptive means agree w/ reference calculations",{
     mndiffs <- sapply(d, function(Data) {with(Data, mean(x1[z==1]) - mean(x1[z==0]))})
     cmndiff <- weighted.mean(mndiffs, w = sapply(d, function(Data) sum(Data$z==1)))
     expect_equivalent(xb1$results["x1", "adj.diff", "s"], cmndiff)
-
+}
 })
 
 test_that("Consistency between lm() and balTest()", {
     set.seed(20180821)
-
+    for(rep_ in nreps_)
+        {
     ## working with aggregated cluster totals already
     n <- 100
 
@@ -90,13 +91,15 @@ test_that("Consistency between lm() and balTest()", {
     ## now check that balance test gives us the same answers
     expect_equivalent(coef(lm.all)["z"], bt.all$results["x1", "adj.diff", ])
     expect_equivalent(coef(lm.lost)["z"], bt.zeroed$results["x1", "adj.diff", ])
-
+}
     
 })
 
 test_that("balT inferentials, incl. agreement w/ Rao score test for cond'l logistic regr",{
     library(survival)
     set.seed(20160406)
+    for(rep_ in nreps_)
+        {    
     n <- 51 # increase at your peril -- clogit can suddenly get slow as stratum size increases
      dat <- data.frame(x1=rnorm(n), x2=rnorm(n),
                         s=rep(c("a", "b"), c(floor(n/2), ceiling(n/2)))
@@ -129,13 +132,15 @@ test_that("balT inferentials, incl. agreement w/ Rao score test for cond'l logis
     ## statistics.  Unremarkable here, but can be alarming when you see it on the screen (cf #75 ). 
     expect_true(all(colSums(xb3$results[,'z',]^2, na.rm=T) < xb3$overall[,'chisquare']))
 }
-          )
+          })
 
 test_that("balT returns covariance of tests", {
   set.seed(20130801)
   n <- 500
 
   library(MASS)
+    for(rep_ in nreps_)
+        {  
   xs <- mvrnorm(n,
                 mu = c(1,2,3),
                 Sigma = matrix(c(1, 0.5, 0.2,
@@ -167,7 +172,7 @@ test_that("balT returns covariance of tests", {
   ## have to filter out rows and cols named "(Intercept)", separately for each
   ## entry in list tcov.  (Recording while updating test that follows, `c(4,4)` --> `c(5,5)`)
   expect_equal(dim(tcov[[1]]), c(5,5))
-
+}
 })
 
 test_that("Passing post.alignment.transform, #26", {
@@ -297,6 +302,8 @@ test_that("p.adjust.method argument", {
 
 test_that("NAs properly handled", {
   set.seed(2903934)
+    for(rep_ in nreps_)
+        {
   n <- 20
   df <- data.frame(Z = rep(c(0,1), n/2),
                    X1 = rnorm(n),
@@ -313,6 +320,7 @@ test_that("NAs properly handled", {
   expect_s3_class(bt2, "xbal")
   expect_true("(X1)" %in% dimnames(bt2[["results"]])[["vars"]])
   expect_false("(_non-null record_)" %in% dimnames(bt2[["results"]])[["vars"]])
+  }
 })
 
 ## To do: adapt the below to test print.xbal instead of lower level functions
@@ -320,7 +328,8 @@ test_that("NAs properly handled", {
 replicate(0,
 {
     set.seed(20130801)
-
+    for(rep_ in nreps_)
+        {
   d <- data.frame(
       x = rnorm(500),
       f = factor(sample(c("A", "B", "C"), size = 500, replace = T)),
@@ -337,6 +346,7 @@ replicate(0,
 
   expect_equal(dim(design.flags@Covariates)[2], 5)
   expect_equal(dim(design.noFlags@Covariates)[2], 4)
+  }
 })
 
 test_that("balanceTest agrees with other methods where appropriate", {
@@ -344,6 +354,8 @@ test_that("balanceTest agrees with other methods where appropriate", {
   library(survival) # for conditional logistic regression
 
   set.seed(20180207)
+    for(rep_ in nreps_)
+        {  
   n <- 100
   x1 <- rnorm(n)
   x2 <- rnorm(n)
@@ -393,4 +405,5 @@ test_that("balanceTest agrees with other methods where appropriate", {
   expect_equivalent(xb2m$overall$chisquare, bt2m$overall['m', "chisquare"])
   expect_equivalent(xb2m$overall$p.value, summary(cr2)$sctest["pvalue"])
   expect_equivalent(bt2m$overall[1, "p.value"], summary(cr2)$sctest[["pvalue"]])
+  }
 })

--- a/tests/testthat/test.balanceTest.R
+++ b/tests/testthat/test.balanceTest.R
@@ -180,24 +180,26 @@ test_that("Passing post.alignment.transform, #26", {
 
   # Identity shouldn't have an effect
   res1 <- balanceTest(pr ~ ., data=nuclearplants)
-  res2 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = function(x) x)
+  res2 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = function(x, y) x)
 
   expect_true(all.equal(res1, res2)) ## allow for small numerical differences
 
-  res3 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = rank)
+  rank_ <-  function(x,y) rank(x)
+  res3 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = rank_)
 
   expect_true(all(dim(res1$results) == dim(res3$results)))
 
-  expect_error(balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = mean),
+  mean_ <- function(x,y) mean(x)
+  expect_error(balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = mean_),
                "Invalid post.alignment.transform given")
 
-  res4 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = rank, report="all")
+  res4 <- balanceTest(pr ~ ., data=nuclearplants, post.alignment.transform = rank_, report="all")
   res5 <- balanceTest(pr ~ ., data=nuclearplants, report="all")
 
   expect_false(isTRUE(all.equal(res4,res5)))
 
   # a wilcoxon rank sum test, asymptotic and w/o continuity correction
-  res6 <- balanceTest(pr ~ cost, data=nuclearplants, post.alignment.transform = rank,
+  res6 <- balanceTest(pr ~ cost, data=nuclearplants, post.alignment.transform = rank_,
                    report="all", p.adjust.method='none')
 
   expect_equal(res6$results["cost", "p", "--"],

--- a/tests/testthat/test.utils.R
+++ b/tests/testthat/test.utils.R
@@ -39,6 +39,18 @@ test_that("fitter for sparse designs handles intercept only design",
               expect_equal(lm.n$residuals, as.vector(slm.n1$residuals))
           }
           )
+test_that("sparse design strat mean calculator returns 0 for strata w/o non-null wts",
+          {
+              expect_true(require("SparseM"))
+              fac <- factor(rep(c("a", "b"), each=2))
+              wts  <- c(1:2, 0, 0)
+              S_ <- SparseMMFromFactor(fac)
+              expect_warning(theslmfit  <- slm.wfit.csr(S_, matrix(1:4), weights=wts),
+                             "singularity problem")
+              expect_equivalent(theslmfit$fitted,
+                                c(rep((1*1+2*2)/(1+2), 2), 0, 0))
+          }
+)          
 
 test_that("Residuals from weighted regressions w/ sparse designs",
           {

--- a/vignettes/matrixNotation.Rnw
+++ b/vignettes/matrixNotation.Rnw
@@ -460,27 +460,28 @@ with variation in weights at the element or sub-cluster level, a
 distinction can be drawn between cluster size, the number of elements
 in the cluster, and cluster \textit{mass}, the clusterwise total of
 element weights.  We interpret the ``${m}_{bc}$'' of
-\citet{hansen:bowers:2008} to mean the latter.  For consistency with
-these concepts, when disaggregated element weights are provided, the
-weight (mass) associated with element $i$, cluster $c$, block $b$ is
-${m}_{bci}$.
+\citet{hansen:bowers:2008} to mean the latter.  
+%% For consistency with
+%% these concepts, when disaggregated element weights are provided, the
+%% weight (mass) associated with element $i$, cluster $c$, block $b$ is
+%% ${m}_{bci}$.
 
 Here we depart from \citet{hansen:bowers:2008} notation by using
 $\mathbf{x}$ to denote a
-matrix of cluster means, calculated with weighting for cluster sizes
-$w$;  when a notation for the matrix of cluster
-totals is needed, we use $\mathbf{t}_{b} = [x_{cr} m_{r} : c\leq n_{b}, r\leq p]$.
+matrix of cluster means, calculated with weighting for element masses;  when a notation for the matrix of cluster
+totals is needed, we use (setting aside missingness in $x$, for now)
+$\mathbf{t}_{b} = [x_{bcr} m_{bc} : c\leq n_{b}, r\leq p]$.
 The adjusted mean differences of \citet{hansen:bowers:2008} become
 \begin{align}
    d(\mathbf{Z}, \mathbf{t}) =& \sum_{b=1}^B w_b h_b^{-1} \bar{m}_b^{-1} \mathbf{Z}_{b}' \mathbf{t}_{b} - \sum_{b=1}^B w_b
-  \bar{m}_b^{-1} (n_b - n_{tb})^{-1} \mathbf{1}'\mathbf{t}_{b}   \nonumber \\
+  \bar{m}_b^{-1} (n_b - n_{tb})^{-1} \mathbf{1}'\mathbf{t}_{b}  \label{eq:1} \\
   =& \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_b} \mathbf{Z}_{b}'
  (\mathbf{t}_{b}  - \bar{t}_{b}\mathbf{1}_{b}), \, 
-  \bar{t}_{b} = n_{b}^{-1}\sum_{i} t_{bi}, \nonumber \\
+  \bar{t}_{b} = n_{b}^{-1}\sum_{i} t_{bi},  \label{eq:11} \\
   =& \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_b} \sum_{i\leq n_{b}}{Z}_{bi}
      \left[ {m}_{bi} \vec{x}_{bi} - n_{b}^{-1} \sum_{i\leq n_{b}}
      m_{bi} \vec{x}_{bi}
-     \right] \label{eq:11}  \\
+     \right]  \nonumber \\
   =& \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_b} \sum_{i\leq n_{b}}{Z}_{bi}
      \left[ {m}_{bi} \vec{x}_{bi} - \left(\frac{\sum_{i\leq n_{b}}
      m_{bi}}{n_{b}}\right) \left(\frac{\sum_{i\leq n_{b}}
@@ -500,39 +501,33 @@ where $\bar{m}_{b}$ is the simple average of cluster masses $\{m_{bc}:
   $\vec{x}$'s, i.e. $\{m_{bc} (\vec{x}_{bc} -
   \text{wavg}_{b}(\mathbf{x})) : c\}$; instead they are $\{m_{bc}
   \vec{x}_{bc} - \bar{m}_{b}
-  \text{wavg}_{b}(\mathbf{x})) : c\}$.  (Centered totals are not the same
-  as upweightings of weighted observations centered around weighted
-  means. Losing track of this led to \#  89.)   
+  \text{wavg}_{b}(\mathbf{x})) : c\}$.  Centering on totals is not the same
+  as centering cluster means around the stratumwise weighted averages of
+  cluster means and then multiplying each centered mean by the
+  cluster's mass
+  (cf. \#  89).   ``Stratum alignment'' will refer to \eqref{eq:11},
+  the centering of cluster totals around their (unweighted)
+  within-stratum means.
   
-  On the other hand,
-  if $\mathbf{x}$ has the property that within each $b$,
-  $\text{wavg}_{b}(\mathbf{x}) = 0$, then $\bar{t}_{b} = 0$ and \eqref{eq:12} reduces to 
-  \begin{equation*}
-    \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_b} \mathbf{Z}_{b}'
- \mathbf{t}_{b} = \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_b}
- \mathbf{Z}_{b}'(m_{b} \cdot \mathbf{x}_{b}),
-  \end{equation*}
- $v_{b} \cdot \mathbf{y}_{b} = [v_{bc} y_{bci} : c,i]$.  Thus we
- approach adjusted difference calculations by first \textit{aligning} the
-$\mathbf{x}_{b}$ submatrices, shifting them in such a way that their
-weighted means will be 0.  For the calculation of these means around
-which to center, NAs in $\mathbf{x}$ are omitted, separately for each
-$x$-column. Following this centering, NAs are replaced with 0s to form $\tilde{\mathbf{x}}_{b}$. 
-Then $\text{wavg}_{b}(\tilde{\mathbf{x}}) = 0$ and 
-\begin{equation*} 
-  d(\mathbf{Z}, \mathbf{x})  
-  = \sum_{b=1}^B \frac{w_b}{h_b\bar{m}_{b}}
-  \mathbf{Z}_{b}' ({m}_{b} \cdot \tilde{\mathbf{x}}_{b} 
- ), %\label{eq:2}
-\end{equation*}
-where $\cdot$ indicates unit-wise product. 
+  Now consider the case with potentially distinct missingness patterns
+  for each covariate, and accordingly distinguishable ``mass''-vectors
+  for each covariate, $\mathbf{m}_{1}, \ldots, \mathbf{m}_{r}$.  Continuing to denote overall cluster masses as
+  $\mathbf{m}=[m_{bc}: b, c\leq n_{b}]$, we have $ 0 \leq m_{bcr}
+  \leq m_{bc}$ for each $b,c$.  In this case we define, for each $b,c,r$,
+  \begin{align*}
+    t_{bcr}=& 
+    \begin{cases}
+     0,& m_{bc'r}=0 \text{ for all } c' \leq n_{b}\\
+     m_{bcr}x_{bcr} + (m_{cr}-m_{bcr})\text{wavg}_{b}([x_{bcr}: c\leq
+ n_{b}]),
+ & m_{bc'r}>0 \text{ for any } c' \leq n_{b}, \\ 
+    \end{cases} \\
+        &  \text{where } \text{wavg}_{b}([x_{bcr}: c\leq n_{b}]) = \frac{\sum_{c \leq n_{b}}m_{bcr}x_{bcr}}{\sum_{c \leq n_{b}}m_{bcr}}.
+  \end{align*}
+Then $\mathbf{t}_{b}= [t_{bcr}: c\leq n_{b}, r]$ and $d(\mathbf{Z}, \mathbf{t})$ is understood as in \eqref{eq:1} and \eqref{eq:11}. 
 
-NAs in $\mathbf{x}_{b} $ become 0s in $\tilde{\mathbf{x}}$, in
-effect being imputed to weighted stratum means.  In terms of its
-effects on the values of $d(\mathbf{z}, \mathbf{x}_{(j)})$ or
-$\mathbf{E}_{0}[d(\mathbf{Z}, \mathbf{x}_{(j)}) ]$, this imputation is
-the same as omitting records that have NAs on the $j$-th $x$
-variable.  To instead impute the mean of $\mathbf{x}_{(j)}$ across
+
+(Were we to instead impute the mean of $\mathbf{x}_{(j)}$ across
 strata $b$, as \texttt{xBalance} did in \texttt{RItools} version
 0.1.14 and earlier, would have given the same values for $d(\mathbf{z}, \mathbf{x}_{(j)})$ or
 $\mathbf{E}_{0}[d(\mathbf{Z}, \mathbf{x}_{(j)}) ]$, but would lead to
@@ -540,7 +535,7 @@ somewhat larger calculated values of $\mathrm{Var}_{0}[d(\mathbf{Z}_{b},
 \mathbf{x}_{b(j)}) ]$, and in turn $\mathrm{Var}_{0}[d(\mathbf{Z},
 \mathbf{x}_{(j)}) ]$: \textit{stratum}-mean imputation is
 variance-minimizing, with the end result that the overall balance
-check is more sensitive than it otherwise would be.  (Hansen \& Bowers
+check is more sensitive than it otherwise would be.  Hansen \& Bowers
 [\citeyear{hansen:bowers:2008}] give formulas for these moments.) 
 
 Some conventions about stratum weighting, from \citet{hansen:bowers:2008}:
@@ -598,10 +593,8 @@ As seen earlier, this is the same as to say
   \left( \sum_{b} n_{b} \bar{m}_{b}\right)^{-1}
   \sum_{b}  \frac{n_{b}}{h_{b}} \mathbf{Z}_{b}' (m_{b} \cdot \tilde{\mathbf{x}}_{b}) . 
 \end{equation*}
-Perhaps these should be the default stratum weights for univariate
-inferentials.  They might even be enforced, ie removed from user
-control, eventually. But only for univariate inferentials; for multivariate
-inferentials we might be better advised to stick with the \citet{hansen:bowers:2008}
+Perhaps we could make these a named option for stratum weighting.  But
+note that they differ from the \citet{hansen:bowers:2008}
 recommendation that $w_{b} \propto h_{b} \bar{m}_{b}$. 
 %% \begin{align*}
 %%   d(\mathbf{Z}, \mathbf{x}) &= \sum_{b} \bar{m}_{b}\left\{  \frac{\mathbf{Z}_{b}'
@@ -626,13 +619,7 @@ Additional notes:
 \begin{itemize}
 \item When \citet{small:etal:2007} used
   the Hodges-Lehmann aligned rank test in a cluster randomized study, they aligned and transformed to
-  ranks \textit{prior to} aggregating within the cluster.  Something I hope
-  we'll enable soon (\#64).
-\item That said, the covariate alignment $x \mapsto \tilde{x}$  
-  has the property that you can apply it either before or after aggregating to the cluster
-  level, with the same result. 
-\item In tandem with the planned relocation of $x \mapsto \tilde{x}$ we can off the user some more options
-  for handling missingness in the x's (see  comment on \#64 thread). 
+  ranks \textit{prior to} aggregating within the cluster.  
 \item The advantage of imputation as opposed to simple omission is to
 preserve the common structure across $x$ variables, which will in
 general have different missingness patterns. This in turn is needed


### PR DESCRIPTION
Revision of differences statistic separating within-stratum alignment (of unweighted totals, not weighted means) out missingness imputation (to the weighted stratum mean of non-missing observations). With this change, the differences statistic admits definitions that do not reference within-stratum alignment.   See changes comments to #47 and changes to vignettes/matrixNotation.Rnw .

I've adapted and added tests, but there may well be testing gaps.  I think these changes will allow for a better handling of #85.  Commits following  4694f3d that may appear on the i47-alignOnTotals branch may reflect work toward this rather than the immediate objective of aligning on cluster totals. 